### PR TITLE
[RP-8] feat: Implement details page using api data

### DIFF
--- a/css/details.css
+++ b/css/details.css
@@ -1,8 +1,34 @@
 /* Main */
 main {
+  position: relative;
   max-width: 1280px;
   margin: 0 auto;
   padding: 48px 80px 96px 80px;
+}
+
+.loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  width: 100%;
+  height: 100vh;
+  min-height: 400px;
+  background-color: var(--white);
+}
+.spinner {
+  position: relative;
+  animation: rotator 1.4s linear infinite;
+}
+.path {
+  stroke: var(--primary);
+  stroke-dasharray: 187;
+  stroke-dashoffset: 0;
+  transform-origin: center;
+  animation: dash 1.4s ease-in-out infinite;
 }
 
 .category {
@@ -82,14 +108,18 @@ main {
   margin-bottom: 16px;
 }
 .ingredients ul {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-auto-flow: column;
   gap: 16px;
 }
 .ingredients ul li {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+.ingredients ul li > p {
+  font-weight: var(--fw-m);
 }
 .ingredients .checkbox {
   display: none;
@@ -122,24 +152,24 @@ main {
 }
 
 /* Aside */
-.nutritional {
+.nutrition {
   margin-bottom: 48px;
   padding: 24px 32px 32px 32px;
   border: 1px solid var(--dark-4);
   border-radius: 8px;
   box-shadow: 0 4px 8px 0 rgb(95 99 95 / 10%);
 }
-.nutritional > p {
+.nutrition > p {
   margin-bottom: 16px;
   font-size: var(--fs-xl);
   font-weight: var(--fw-sb);
 }
-.nutritional ul {
+.nutrition ul {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
-.nutritional ul li {
+.nutrition ul li {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -147,6 +177,7 @@ main {
   border-bottom: 1px solid var(--dark-3);
 }
 .recipe-tip {
+  min-height: 200px;
   margin-bottom: 48px;
   padding: 24px 32px;
   border-radius: 8px;
@@ -171,6 +202,7 @@ main {
   font-weight: var(--fw-sb);
 }
 .tags span {
+  margin-right: 8px;
   color: var(--dark-2);
 }
 

--- a/css/global.css
+++ b/css/global.css
@@ -108,3 +108,27 @@ footer {
 .social-links i:hover {
   color: var(--primary-light);
 }
+
+/* keyframes */
+@keyframes rotator {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(270deg);
+  }
+}
+
+@keyframes dash {
+  0% {
+    stroke-dashoffset: 187;
+  }
+  50% {
+    stroke-dashoffset: 46.75;
+    transform: rotate(135deg);
+  }
+  100% {
+    stroke-dashoffset: 187;
+    transform: rotate(450deg);
+  }
+}

--- a/details.html
+++ b/details.html
@@ -13,6 +13,7 @@
     />
     <link rel="stylesheet" href="/css/global.css" />
     <link rel="stylesheet" href="/css/details.css" />
+    <script src="./config.js" defer></script>
     <script src="/js/details.js" defer></script>
   </head>
   <body>
@@ -22,9 +23,36 @@
       </h1>
     </header>
     <main>
-      <div class="category">반찬</div>
+      <div id="loader" class="loader">
+        <svg
+          class="spinner"
+          width="65px"
+          height="65px"
+          viewBox="0 0 66 66"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="33"
+            cy="33"
+            r="30"
+            fill="none"
+            stroke="var(--primary-subtle)"
+            stroke-width="6"
+          />
+          <circle
+            class="path"
+            fill="none"
+            stroke-width="6"
+            stroke-linecap="round"
+            cx="33"
+            cy="33"
+            r="30"
+          />
+        </svg>
+      </div>
+      <div id="category" class="category"></div>
       <div class="title-wrap">
-        <h2 class="title">스트로베리 샐러드</h2>
+        <h2 id="title" class="title"></h2>
         <button class="bookmark-btn active">
           <i class="fa-solid fa-bookmark"></i>
         </button>
@@ -34,114 +62,35 @@
       </div>
       <section class="content-con">
         <div class="contents">
-          <div class="recipe-img">
-            <img src="./assets/image2.png" alt="image 2" />
+          <div id="main-image" class="recipe-img">
+            <img src="./assets/no-image.jpg" alt="image 2" />
           </div>
           <div class="ingredients">
             <h3>재료</h3>
-            <ul>
-              <li>
-                <input type="checkbox" class="checkbox" />
-                <span class="checkmark"></span>
-                <span>딸기 70g(7개)</span>
-              </li>
-              <li>
-                <input type="checkbox" class="checkbox" checked />
-                <span class="checkmark"></span>
-                <span>플레인요거트 85g(1개)</span>
-              </li>
-              <li>
-                <input type="checkbox" class="checkbox" checked />
-                <span class="checkmark"></span>
-                <span>양상추 70g(2장)</span>
-              </li>
-              <li>
-                <input type="checkbox" class="checkbox" checked />
-                <span class="checkmark"></span>
-                <span>메추리알 30g(3개)</span>
-              </li>
-              <li>
-                <input type="checkbox" class="checkbox" />
-                <span class="checkmark"></span>
-                <span>블루베리 15g(1큰술)</span>
-              </li>
-              <li>
-                <input type="checkbox" class="checkbox" checked />
-                <span class="checkmark"></span>
-                <span>식초 약간</span>
-              </li>
-              <li>
-                <input type="checkbox" class="checkbox" checked />
-                <span class="checkmark"></span>
-                <span>소금 약간</span>
-              </li>
-            </ul>
+            <ul id="ingredients-list"></ul>
           </div>
         </div>
         <aside>
-          <div class="nutritional">
+          <div class="nutrition">
             <p>영양성분</p>
-            <ul>
-              <li><span>칼로리</span><span>200kcal</span></li>
-              <li><span>탄수화물</span><span>40g</span></li>
-              <li><span>지방</span><span>4g</span></li>
-              <li><span>단백질</span><span>1g</span></li>
-              <li><span>나트륨</span><span>1,000mg</span></li>
-            </ul>
+            <ul id="nutrition-list"></ul>
           </div>
           <div class="recipe-tip">
             <p class="tip-title">
               <i class="fa-solid fa-lightbulb"></i> 저감 조리법 TIP
             </p>
-            <p class="tip-content">
-              딸기는 칼륨이 풍부하여 나트륨 배출에 뛰어나지만 칼슘이 부족한
-              과일이예요. 그렇기 때문에 칼슘이 풍부한 요거트나 기타 유제품과
-              함께 섭취하면 좋아요.
-            </p>
+            <p id="tip-content" class="tip-content"></p>
           </div>
-          <div class="tags">
+          <div id="tags" class="tags">
             <p>태그</p>
-            <span># 딸기</span>
           </div>
         </aside>
       </section>
       <section class="steps-con">
         <h3>조리 순서</h3>
-        <ul>
-          <li>
-            <div class="step-img">
-              <img src="./assets/step1.png" alt="step 1" />
-            </div>
-            <div class="step-num">1</div>
-            <p>
-              찬물이 담긴 냄비에 식초, 소금을 넣고 메추리알을 삶는다. 물이
-              끓어오르면 5분 정도 더 삶아 찬물에 헹군 후 껍질을 벗기고 반으로
-              자른다.
-            </p>
-          </li>
-          <li>
-            <div class="step-img">
-              <img src="./assets/step2.png" alt="step 2" />
-            </div>
-            <div class="step-num">2</div>
-            <p>
-              딸기를 흐르는 물에 가볍게 씻어 꼭지를 제거한 후 물기를 빼고 반으로
-              자른다.
-            </p>
-          </li>
-          <li>
-            <div class="step-img">
-              <img src="./assets/step3.png" alt="step 3" />
-            </div>
-            <div class="step-num">3</div>
-            <p>
-              양상추는 찬물에 담갔다가 물기를 빼고 한입 크기로 찢은 후 접시에
-              양상추, 딸기, 블루베리, 메추리알을 담고 플레인요거트를 끼얹는다.
-            </p>
-          </li>
-        </ul>
+        <ul id="cooking-steps"></ul>
       </section>
-      <button class="back-btn">목록으로</button>
+      <button id="back-btn" class="back-btn">목록으로</button>
     </main>
     <footer>
       <div class="footer-inner">

--- a/js/details.js
+++ b/js/details.js
@@ -1,0 +1,171 @@
+const $backToListBtn = document.getElementById('back-btn');
+// 새로고침 시 sessionStorage에 저장된 정보 불러오기 (api 재호출 방지)
+const storedData = sessionStorage.getItem('pageData');
+let recipeData = storedData ? JSON.parse(storedData) : null;
+
+const fetchData = async (url) => {
+  try {
+    const response = await fetch(url);
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
+};
+
+/**
+ * 로딩 화면 제어
+ * @param {boolean} isLoading
+ */
+const toggleLoading = (isLoading) => {
+  const $loader = document.getElementById('loader');
+  $loader.style.display = isLoading ? 'flex' : 'none';
+  document.body.style.overflow = isLoading ? 'hidden' : '';
+};
+
+/**
+ * 파일 확장자 체크
+ * @param {string} path
+ */
+const isImageFormat = (path) => {
+  const pngPattern = /\.(png)$/i;
+  const jpgPattern = /\.(jpg|jpeg)$/i;
+  return pngPattern.test(path) || jpgPattern.test(path) ? path : null;
+};
+
+/** 재료 리스트 생성 */
+const createIngredients = () => {
+  const $ingredientsList = document.getElementById('ingredients-list');
+  const fragment = document.createDocumentFragment();
+
+  // ,와 \n, :, -를 기준으로 문자열 분리 (단, 괄호() 안의 ,는 포함)
+  const ingredientsArr = recipeData.RCP_PARTS_DTLS.replace(
+    /-\s*[^:]*\s*:|\[[^\]]*\]|재료|●\s*[^:]*\s*:|·\s*[^:]*\s*:|\n|저나트륨[^:]*/g,
+    ',',
+  )
+    .replace(/(\([^)]*)\s*,\s*/g, '$1__COMMA__')
+    .split(/,|, |:/)
+    .map((part) => part.replace(/__COMMA__/g, ','));
+  let liCount = 0;
+
+  ingredientsArr.forEach((item) => {
+    const newItem = document.createElement('li');
+    if (!item.trim() || item.trim() === recipeData.RCP_NM.replace(/\s+/g, ''))
+      return;
+
+    /* 추후 checkbox checked 변경 */
+    newItem.innerHTML = `<input type="checkbox" class="checkbox" checked />
+                        <span class="checkmark"></span>
+                        <span>${item}</span>`;
+    liCount++;
+    fragment.appendChild(newItem);
+  });
+  $ingredientsList.style.gridTemplateRows = `repeat(${Math.ceil(
+    liCount / 2,
+  )}, auto)`;
+  $ingredientsList.appendChild(fragment);
+};
+
+/** 영양성분 표시 */
+const createNutrition = () => {
+  const $nutritionList = document.getElementById('nutrition-list');
+
+  $nutritionList.innerHTML = `
+                              <li><span>칼로리</span><span>${
+                                recipeData.INFO_ENG
+                              }kcal</span></li>
+                              <li><span>탄수화물</span><span>${
+                                recipeData.INFO_CAR
+                              }g</span></li>
+                              <li><span>지방</span><span>${
+                                recipeData.INFO_FAT
+                              }g</span></li>
+                              <li><span>단백질</span><span>${
+                                recipeData.INFO_PRO
+                              }g</span></li>
+                              <li><span>나트륨</span><span>${Number(
+                                recipeData.INFO_NA,
+                              ).toLocaleString()}mg</span></li>`;
+};
+
+/** 조리 순서 생성 */
+const createSteps = () => {
+  const $cookingSteps = document.getElementById('cooking-steps');
+  const fragment = document.createDocumentFragment();
+
+  const stepList = Object.fromEntries(
+    Object.entries(recipeData).filter(
+      ([key, value]) => key.includes('MANUAL') && !key.includes('IMG') && value,
+    ),
+  );
+
+  Object.entries(stepList).forEach(([key, value], i) => {
+    const stepNum = key.slice(-2);
+    const stepItem = document.createElement('li');
+
+    stepItem.innerHTML = `<div class="step-img">
+                            <img src="${
+                              recipeData[`MANUAL_IMG${stepNum}`] ||
+                              './assets/no-image.jpg'
+                            }" alt="step ${i + 1}" />
+                          </div>
+                          <div class="step-num">${i + 1}</div>
+                          <p>${value.replace(/\b\d+\.|[.][a-z]/g, '')}</p>`;
+    fragment.appendChild(stepItem);
+  });
+  $cookingSteps.appendChild(fragment);
+};
+
+// 페이지 로드 및 렌더링
+const renderPage = async () => {
+  const $category = document.getElementById('category');
+  const $title = document.getElementById('title');
+  const $mainImg = document.querySelector('#main-image > img');
+  const $reducedTip = document.getElementById('tip-content');
+  const $tags = document.getElementById('tags');
+
+  // mock server
+  const baseUrl = `https://b24ec182-58f9-4bde-932e-7428a89fac14.mock.pstmn.io/api/${API_KEY}/COOKRCP01/json/1/1000`;
+  const urlParams = new URLSearchParams(window.location.search);
+  const recipeName = urlParams.get('recipeName');
+
+  toggleLoading(true);
+
+  if (!recipeData || recipeData.RCP_NM !== recipeName) {
+    const data = await fetchData(`${baseUrl}/RCP_NM=${recipeName}`);
+    // recipeName과 완전히 동일한 데이터만 저장
+    recipeData =
+      data.COOKRCP01.total_count === '1'
+        ? data.COOKRCP01.row[0]
+        : data.COOKRCP01.row.find((x) => x.RCP_NM === recipeName);
+    sessionStorage.setItem('pageData', JSON.stringify(recipeData));
+  }
+
+  toggleLoading(false);
+
+  $category.textContent = recipeData.RCP_PAT2.replace('&', '/');
+  $title.textContent = recipeData.RCP_NM;
+
+  // ATT_FILE_NO_MAIN이 없는 경우 ATT_FILE_NO_MK로 대체. 둘 다 없는 경우 no-image
+  $mainImg.src =
+    isImageFormat(recipeData.ATT_FILE_NO_MAIN) ||
+    isImageFormat(recipeData.ATT_FILE_NO_MK) ||
+    './assets/no-image.jpg';
+
+  $reducedTip.textContent =
+    recipeData.RCP_NA_TIP || '해당 조리법의 TIP이 없어요.';
+  if (!recipeData.RCP_NA_TIP) $reducedTip.style.color = 'var(--dark-2)';
+
+  const tag = document.createElement('span');
+  tag.textContent = recipeData.HASH_TAG ? `# ${recipeData.HASH_TAG}` : '-';
+  $tags.appendChild(tag);
+
+  createIngredients();
+  createNutrition();
+  createSteps();
+};
+
+$backToListBtn.addEventListener('click', () => {
+  window.location.href = 'index.html';
+});
+
+renderPage();

--- a/js/index.js
+++ b/js/index.js
@@ -2,12 +2,16 @@ const $categoryList = document.getElementById('category');
 const $cardCount = document.getElementById('card-count');
 const $cardList = document.getElementById('card-list');
 
+const categoryCache = {};
 let isLoading = false;
 
-const fetchData = async (url) => {
+const fetchData = async (url, categoryId) => {
   try {
+    if (categoryCache[categoryId]) return categoryCache[categoryId];
+
     const response = await fetch(url);
     const data = await response.json();
+    categoryCache[categoryId] = data;
     return data;
   } catch (error) {
     console.error('Error fetching data:', error);
@@ -21,9 +25,12 @@ const createCardList = async (queryParams = {}) => {
   document.querySelector('.loading').style.display = 'flex';
 
   // mock server
-  const baseUrl = `https://fdbac7e9-cc88-4e30-9a85-03b4bd0e4f09.mock.pstmn.io/api/${API_KEY}/COOKRCP01/json/1/1000`;
+  const baseUrl = `https://b24ec182-58f9-4bde-932e-7428a89fac14.mock.pstmn.io/api/${API_KEY}/COOKRCP01/json/1/1000`;
   const queryString = new URLSearchParams(queryParams).toString();
-  const data = await fetchData(`${baseUrl}/${queryString}`);
+  const data = await fetchData(
+    `${baseUrl}/${queryString}`,
+    queryParams.RCP_PAT2,
+  );
   const recipes = data.COOKRCP01.row;
   const cardCount = data.COOKRCP01.total_count;
   const fragment = document.createDocumentFragment();
@@ -52,8 +59,8 @@ const createCardList = async (queryParams = {}) => {
                             )}</div>
                           </div>
                         </div>
-                        <a href="details.html?seq=${
-                          recipe.RCP_SEQ
+                        <a href="details.html?recipeName=${
+                          recipe.RCP_NM
                         }" id="details-link"></a>
                         `;
     fragment.appendChild(newCard);
@@ -86,5 +93,4 @@ const handleCategoryClick = async (e) => {
 };
 
 $categoryList.addEventListener('click', handleCategoryClick);
-
 createCardList();


### PR DESCRIPTION
## 상세 페이지 API 통합 구현
- api (mock-server 사용) 호출하여 sessionStorage 저장
- 같은 페이지 새로고침 시, 저장한 데이터 불러오기
- url parameter(recipeName) 값으로 api 호출
- api 호출 시간 동안 loading 표시

### category
- '국&찌개'인 경우 & -> /로 변경
- 그 이외 동일

### title
- 메뉴명(RCP_NM)

### main image
- ATT_FILE_NO_MAIN(기본값) 존재하지 않는 경우, ATT_FILE_NO_MK로 대체
- 둘 다 존재하지 않는 경우, no-image 표시
- ATT_FILE_NO_MAIN와 ATT_FILE_NO_MK의 확장자가 .png/.jpg/.jpeg에 속하지 않는 경우 체크 (몇몇 데이터 확장자 올바르지 않음)

### ingredients
- 재료 정보(RCP_PARTS_DTLS)의 각 재료를 comma 기준 배열로 분리
  - 특수문자 ●, ・ 및 대괄호[], hyphen(-), colon(:) 제외
  - '재료', '저나트륨 ~' 등 실제 재료가 아닌 부가 정보 제외
  - 소괄호() 내부 comma(,)는 제외시키지 않도록 유의 e.g. 새우(대하, 3마리)
- 2 columns grid 형태

### nutrition
- 열량(INFO_ENG), 탄수화물(INFO_CAR), 지방(INFO_FAT), 단백질(INFO_PRO), 나트륨(INFO_NA) 표시
  - 나트륨 천 단위 comma 표시
 
### reduced tip
- 저감 조리법 TIP(RCP_NA_TIP) 표시
- 빈 값인 경우, 다른 문구 표시

### tag
- 해시태그(HASH_TAG). # {tag name} 형태로 표시
- 빈 값인 경우, '-'로 대체  

### cooking steps
- 조리 방법은 MANUAL01와 같은 형태, 이미지는 MANUAL_IMG01과 같은 형태
- MANUAL이 접두어로 붙고 IMG가 포함되지 않은 key값 추출
- 조리 방법의 순서와 동일한 이미지 매칭하여 순서 리스트 구현
- 조리 방법 내 1.과 같은 {number}{comma} 문자 또는 .a와 같은 {comma}{small letter} 문자 제외

### backToList button
- '목록으로' 버튼 클릭 시 메인 페이지로 이동